### PR TITLE
Rewrite WallsFragment class

### DIFF
--- a/app/src/main/java/com/alexcruz/papuhwalls/Callback.java
+++ b/app/src/main/java/com/alexcruz/papuhwalls/Callback.java
@@ -1,0 +1,5 @@
+package com.alexcruz.papuhwalls;
+
+public interface Callback<V> {
+    void callback(V object);
+}


### PR DESCRIPTION
- Instead of Picasso targets we're using AsyncTask with callback
- Fix some inconsistency (sometimes target was using bitmap taken from ImageView instead of downloaded one)
- Remove useless download progress dialog
- Fix immersive losing when returning to activity or closing dialog